### PR TITLE
Don't flush if not dirty

### DIFF
--- a/lib/model.go
+++ b/lib/model.go
@@ -54,6 +54,9 @@ type Model interface {
 	 */
 	PushTransform(ot OTransform) (OTransform, int, error)
 
+	/* Returns true, if the model have unapplied transforms that can be flushed */
+	IsDirty() bool
+
 	/* FlushTransforms - apply all unapplied transforms to content, and delete old applied
 	 * in accordance with our retention period. Returns a bool indicating whether any changes
 	 * were applied, and an error in case a fatal problem was encountered.

--- a/lib/model_text.go
+++ b/lib/model_text.go
@@ -125,6 +125,13 @@ func (m *OModel) PushTransform(ot OTransform) (OTransform, int, error) {
  */
 
 /*
+Check if there is any unapplied transforms
+*/
+func (m *OModel) IsDirty() bool {
+	return len(m.Unapplied) > 0
+}
+
+/*
 GetVersion - returns the current version of the document.
 */
 func (m *OModel) GetVersion() int {


### PR DESCRIPTION
Fixing issues where leaps flushes the document even when there is no changes...

Ideally we should have changed `flush()` to not load the document if there isn't any changes, but the function is also abused for other purposes...

Note: another side-effect of `FlushTransforms` is that applied transforms are deleted from memory. But if no new transform are coming in, then I don't think it's a high priority to drop the ones we have in memory.

Besides this probably shouldn't be coupled with binders anyways, ie. clearing applied transforms should be done independent from flush...