### PR TITLE
Initial work on making userId and token unconfused

### DIFF
--- a/lib/binder_portal.go
+++ b/lib/binder_portal.go
@@ -55,11 +55,11 @@ type MessageSubmission struct {
 
 /*
 BinderSubscribeBundle - A container that holds all data necessary to provide a binder that you
-wish to subscribe to. Contains a user token for identifying the client and a channel for
+wish to subscribe to. Contains a user userId for identifying the client and a channel for
 receiving the resultant BinderPortal.
 */
 type BinderSubscribeBundle struct {
-	Token         string
+	UserId        string
 	PortalRcvChan chan<- BinderPortal
 }
 
@@ -80,7 +80,6 @@ allowing fresh transforms to be submitted and returned as they come. Also carrie
 of the client.
 */
 type BinderPortal struct {
-	Token            string
 	UserId           string
 	Client           *BinderClient
 	Document         store.Document


### PR DESCRIPTION
Just getting started on this... Feel free to jump in too...

I've made all members of `BinderClient` lower case so they won't be exported (If I recall go correctly)..

Then use `*BinderClient` pointer instead of token as the identifier... I suspect we should get completely rid of `BinderClient` and instead just use `BinderPortal`.

I think this is almost mergeable now, feel free to give it a quick... I haven't really tested it... Next step is to ensure that we always have a userId... I think right now it's just an empty string because I don't set it...

-----

@Jeffail, I suggest we drop the `KickUser(userId string, timeout time.Duration)` functionality, I don't see the use-case when the kicked user can immediately reconnect. Something like this is better solved at auth level, and kicking a user that is currently watching seems like something very complicated.

It seems more realistic that an auth provider implements a way to purge a token, and the next time the client reconnects the client won't be granted access.  But kicking active clients as well, seems too hard (with too little usecase). If we really wanted it, it would probably be better than auth had a method it could call forcing all binders to re-evaluate all tokens, and then kick users.

IMO this is however not a good feature at this point. Agree?