### PR TITLE
fixed font url

### DIFF
--- a/cmd/leaps/www/index.html
+++ b/cmd/leaps/www/index.html
@@ -9,7 +9,7 @@
 		<script type="text/javascript" src="leaps.js"></script>
 		<script type="text/javascript" src="leap-ace.js"></script>
 		<script type="text/javascript" src="leapshare.js"></script>
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+		<link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 		<link href="style.css" type="text/css" rel="stylesheet">
 	</head>
 	<body class="white">


### PR DESCRIPTION
with this little fix, it will work on `http` and `https`, see
http://www.amixa.com/blog/2012/06/06/how-to-use-google-fonts-under-both-ssl-and-non-ssl-without-ssl-insecure-messages/