### PR TITLE
Update UUID vendor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,132 +2,190 @@
 
 
 [[projects]]
+  digest = "1:a6775ff69b2873c65581fd54fcddb86b58ef0f1ab34fe6b27ddb4e5e47c92824"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
     "autorest/adal",
     "autorest/azure",
-    "autorest/date"
+    "autorest/date",
   ]
+  pruneopts = "UT"
   revision = "fc3b03a2d2d1f43fad3007038bd16f044f870722"
   version = "v9.10.0"
 
 [[projects]]
+  digest = "1:00ce6d124c3df5ca3073384f40a22c0c252e2962d433a90beb71ac2c95bc222c"
   name = "github.com/Jeffail/gabs"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2a3aa15961d5fee6047b8151b67ac2f08ba2c48c"
   version = "1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8c1eb57ba1e7e111c4365b4447b4ec979e157ea34445b3d29feac0744c9389ee"
   name = "github.com/amir/raidman"
   packages = [
     ".",
-    "proto"
+    "proto",
   ]
+  pruneopts = "UT"
   revision = "1ccc43bfb9c93cb401a4025e49c64ba71e5e668b"
 
 [[projects]]
+  digest = "1:83011415dd20f73927f4152e8de3bfdbcf6eb94ea61e0c8cedee1d86070073cb"
   name = "github.com/azure/azure-sdk-for-go"
   packages = ["storage"]
+  pruneopts = "UT"
   revision = "21b68149ccf7c16b3f028bb4c7fd0ab458fe308f"
   version = "v12.5.0-beta"
 
 [[projects]]
+  digest = "1:4ba637038f22c9065994c0cd734118fc75e0c744f855fd3edbd3b923d1f41d44"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
+  pruneopts = "UT"
   revision = "61153c768f31ee5f130071d08fc82b85208528de"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:217f778e19b8d206112c21d21a7cc72ca3cb493b67631680a2324bc50335d432"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
   version = "v3.1.0"
 
 [[projects]]
+  digest = "1:f4f6279cb37479954644babd8f8ef00584ff9fa63555d2c6718c1c3517170202"
   name = "github.com/elazarl/go-bindata-assetfs"
   packages = ["."]
+  pruneopts = "UT"
   revision = "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:d28347c2e8e3b4db1dc17f8188d997402c59ad85bd33288b5b92515d6d89d072"
   name = "github.com/garyburd/redigo"
   packages = [
     "internal",
-    "redis"
+    "redis",
   ]
+  pruneopts = "UT"
   revision = "d1ed5c67e5794de818ea85e6b522fda02623a484"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:850c49ca338a10fec2cb9e78f793043ed23965489d09e30bcc19fe29719da313"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a0583e0143b1624142adab07e0e97fe106d99561"
   version = "v1.3"
 
 [[projects]]
+  digest = "1:c594a691090b434d55c67f6cc8e326ef5ba49452abc059821bd5d4fd4cdef08c"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7077aa61129615a0d7f45c49101cd011ab221c27"
+  version = "v3.1.2"
+
+[[projects]]
+  digest = "1:ffc060c551980d37ee9e428ef528ee2813137249ccebb0bfc412ef83071cac91"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:caf6db28595425c0e0f2301a00257d11712f65c1878e12cffc42f6b9a9cf3f23"
   name = "github.com/kardianos/osext"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
   branch = "master"
+  digest = "1:bd26bbaf1e9f9dfe829a88f87a0849b56f717c31785443a67668f2c752fa8412"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid"
+    "oid",
   ]
+  pruneopts = "UT"
   revision = "88edab0803230a3898347e77b474f8c1820a1f20"
 
 [[projects]]
+  digest = "1:4e878df5f4e9fd625bf9c9aac77ef7cbfa4a74c01265505527c23470c0e40300"
   name = "github.com/marstr/guid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "8bdf7d1a087ccc975cf37dd6507da50698fd19ca"
 
 [[projects]]
+  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a88b9051daa019223f01d6d9d35abfb1f17a665c4e0b50091584c6036856e32f"
   name = "golang.org/x/net"
   packages = [
     "context",
-    "proxy"
+    "proxy",
   ]
+  pruneopts = "UT"
   revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
 [[projects]]
+  digest = "1:38b469493eb173db9c03321d64adcad4c7991ea0a19b5edc5bdc094f0e8c7384"
   name = "gopkg.in/alexcesaro/statsd.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7fea3f0d2fab1ad973e641e51dba45443a311a90"
   version = "v2.0.0"
 
 [[projects]]
   branch = "v2"
+  digest = "1:73e6fda93622790d2371344759df06ff5ff2fac64a6b6e8832b792e7402956e7"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3ddb55d95c9c41adbf1b58c629f07f17442179c2a2927e3e38df7aa5fa99f6f"
+  input-imports = [
+    "github.com/Jeffail/gabs",
+    "github.com/amir/raidman",
+    "github.com/azure/azure-sdk-for-go/storage",
+    "github.com/cenkalti/backoff",
+    "github.com/elazarl/go-bindata-assetfs",
+    "github.com/garyburd/redigo/redis",
+    "github.com/go-sql-driver/mysql",
+    "github.com/gofrs/uuid",
+    "github.com/gorilla/websocket",
+    "github.com/kardianos/osext",
+    "github.com/lib/pq",
+    "gopkg.in/alexcesaro/statsd.v2",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -66,8 +66,8 @@
   name = "github.com/lib/pq"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2.0"
+  name = "github.com/gofrs/uuid"
+  version = "3.1.2"
 
 [[constraint]]
   name = "gopkg.in/alexcesaro/statsd.v2"

--- a/lib/util/uuid_gen.go
+++ b/lib/util/uuid_gen.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 /*--------------------------------------------------------------------------------------------------
@@ -48,7 +48,8 @@ func GenerateStampedUUID() string {
 GenerateUUID - Generates a UUID and returns it as a hex encoded string.
 */
 func GenerateUUID() string {
-	return uuid.NewV4().String()
+	u, _ := uuid.NewV4()
+	return u.String()
 }
 
 /*--------------------------------------------------------------------------------------------------

--- a/lib/util/uuid_gen.go
+++ b/lib/util/uuid_gen.go
@@ -27,6 +27,7 @@ package util
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -47,8 +48,12 @@ func GenerateStampedUUID() string {
 /*
 GenerateUUID - Generates a UUID and returns it as a hex encoded string.
 */
+// TODO: handle the error more gracefully
 func GenerateUUID() string {
-	u, _ := uuid.NewV4()
+	u, err := uuid.NewV4()
+	if err != nil {
+		log.Fatal(err)
+	}
 	return u.String()
 }
 


### PR DESCRIPTION
It appears github.com/satori/go.uuid is functionally deprecated,
and has been superceded by github.com/gofrs/uuid.

- github.com/satori/go.uuid#84
- github.com/satori/go.uuid#90

This came to my attention because of un-tagged changes to
satori/go.uuid that changed the signature of uuid.NewV4()
from a single return val to two, resulting in:

```
$ go get github.com/Jeffail/leaps/cmd/...
warning: ignoring symlink /Users/ia/go/src/github.com/Jeffail/leaps/cmd/leaps/www
warning: ignoring symlink /Users/ia/go/src/github.com/Jeffail/leaps/cmd/leaps/www
# github.com/Jeffail/leaps/lib/util
go/src/github.com/Jeffail/leaps/lib/util/uuid_gen.go:51:19: multiple-value uuid.NewV4() in single-value context
```

Of course running 'dep ensure' fixed this issue, but
it seems like this project should use the 'longer fork'
of this dependency in any case.